### PR TITLE
fix: cors issue on Macbook

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,7 @@ server {
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
         add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        add_header 'Access-Control-Allow-Private-Network' 'true';
 
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' 'https://www.boot.dev';
@@ -18,6 +19,7 @@ server {
             add_header 'Access-Control-Max-Age' 1728000;
             add_header 'Content-Type' 'text/plain charset=UTF-8';
             add_header 'Content-Length' 0;
+            add_header 'Access-Control-Allow-Private-Network' 'true';
             return 204;
         }
 


### PR DESCRIPTION
set header Access-Control-Allow-Private-Network to true

to fix CORS issues on Macbook Chrome when checking tasks 
issue:
```
Access to fetch at 'http://localhost/' from origin 'https://www.boot.dev' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Private-Network' header was present in the preflight response for this private network request targeting the `local` address space.
```